### PR TITLE
Fix compilation error on recent rustc versions

### DIFF
--- a/src/atpath.rs
+++ b/src/atpath.rs
@@ -63,7 +63,7 @@ impl<'at> AtPath<'at> {
             let mut unprefixed = PathBuf::new();
             for component in prefixed.components()
                                      .skip(self.subdir.components().count()) {
-                unprefixed.push(component.as_ref().to_str().unwrap());
+                unprefixed.push(component);
             }
             unprefixed
         } else {


### PR DESCRIPTION
    error[E0282]: type annotations needed
      --> src/atpath.rs:66:52
       |
    66 |                 unprefixed.push(component.as_ref().to_str().unwrap());
       |                                                    ^^^^^^ cannot infer type for `T`